### PR TITLE
fix:avoid build and push for chanes in feature branches

### DIFF
--- a/.github/workflows/github-action-push-to-remote.yml
+++ b/.github/workflows/github-action-push-to-remote.yml
@@ -1,4 +1,4 @@
-name: Push to Remote Repository
+name: 🔃 Push to Remote Repository
 
 on:
   workflow_dispatch:  # Allows manual triggering
@@ -8,6 +8,8 @@ on:
       - '!README.md'
       - '!.github/**/*.md'
       - '!.env.example'
+    branches:
+      - 'main'
 
 jobs:
   push_to_remote:
@@ -20,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-        
+
       - name: Push changes
         run: |
           wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -O /usr/local/bin/cloudflared &&

--- a/.github/workflows/github-actions-push-image.yml
+++ b/.github/workflows/github-actions-push-image.yml
@@ -8,6 +8,8 @@ on:
       - '!.github/**/*.md'
       # - '!.github/workflows/**'
       - '!.env.example'
+    branches:
+      - 'main'
 
 env:
   REGISTRY: index.docker.io

--- a/.github/workflows/linets.yml
+++ b/.github/workflows/linets.yml
@@ -1,4 +1,4 @@
-name: Linters
+name: 📝 Linters
 on:
   push:
     branches:


### PR DESCRIPTION
Recently, the dependabot created PRs to bump external dependency, it was created as the push to the feature branch of the same repo and CI was triggered due to:

```
on:
  push:
    paths:
      - '**'
      - '!README.md'
      - '!.github/**/*.md'
      # - '!.github/workflows/**'
      - '!.env.example'
```

So, any commit to any feature branch will trigger a new docker image and sync with dokku which should be avoided, and only changes in `main` branch should be considered as the CI triggers (beside linters and tests, if any).

Within this PR I limits triggers of CI to the `main` branch 
