### PR TITLE
feat: Add facebook to supported sites

### DIFF
--- a/src/permissions.py
+++ b/src/permissions.py
@@ -35,6 +35,7 @@ def is_user_or_chat_not_allowed(username: Optional[str], chat_id: int) -> bool:
 
 supported_sites = [
     "**https://",
+    "facebook.com/",
     "instagram.com/",
     "tiktok.com/",
     "reddit.com/",


### PR DESCRIPTION
As per [supported sites](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md), Facebook reels are supported.

Tested - `OK` on https://www.facebook.com/share/r/1WgCrNGvad/?mibextid=wwXIfr or https://www.facebook.com/reel/373888835813407 (same video, different link)

```
downloader-bot  | [generic] Extracting URL: https://www.facebook.com/share/r/1WgCrNGvad/?mibextid=wwXIfr
downloader-bot  | [generic] ?mibextid=wwXIfr: Downloading webpage
downloader-bot  | [redirect] Following redirect to https://www.facebook.com/reel/373888835813407?mibextid=wwXIfr&rdid=gBsJ8E07z3nNvazj&share_url=https%3A%2F%2Fwww.facebook.com%2Fshare%2Fr%2F1WgCrNGvad%2F%3Fmibextid%3DwwXIfr
downloader-bot  | [facebook:reel] Extracting URL: https://www.facebook.com/reel/373888835813407?mibextid=wwXIfr&rdid=gBsJ8E07z3nNvazj&share_url=htt...%3Fmibextid%3DwwXIfr
downloader-bot  | [facebook] Extracting URL: https://m.facebook.com/watch/?v=373888835813407&_rdr
downloader-bot  | [facebook] 373888835813407: Downloading webpage
downloader-bot  | [info] 373888835813407: Downloading 1 format(s): hd
downloader-bot  | [download] Destination: /tmp/tmp1cphou5e/373888835813407.mp4
[download] 100% of    2.25MiB in 00:00:00 at 15.06MiB/s
downloader-bot  | Video to delete /tmp/tmp1cphou5e/373888835813407.mp4
downloader-bot  | Video deleted /tmp/tmp1cphou5e/373888835813407.mp4
downloader-bot  | [facebook:reel] Extracting URL: https://www.facebook.com/reel/373888835813407
downloader-bot  | [facebook] Extracting URL: https://m.facebook.com/watch/?v=373888835813407&_rdr
downloader-bot  | [facebook] 373888835813407: Downloading webpage
downloader-bot  | [info] 373888835813407: Downloading 1 format(s): hd
downloader-bot  | [download] Destination: /tmp/tmpzi_yocsi/373888835813407.mp4
[download] 100% of    2.25MiB in 00:00:00 at 15.53MiB/s
downloader-bot  | Video to delete /tmp/tmpzi_yocsi/373888835813407.mp4
downloader-bot  | Video deleted /tmp/tmpzi_yocsi/373888835813407.mp4
```