### PR TITLE
doc: Add facebook to supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ sudo systemctl status downloader-bot.service
 
 ### Supported platforms by default:
 ```
+facebook
 instagram reels
 tiktok
 reddit


### PR DESCRIPTION
Update doc as per https://github.com/ovchynnikov/load-bot-linux/pull/20