### PR TITLE
feat: New env vars for logging ADMINS_CHAT_IDS, SEND_ERROR_TO_ADMIN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
-# Telegram Bot Configuration
-BOT_TOKEN="your_telegram_bot_token_here"  # Get this from @BotFather on Telegram
+# Telegram Bot Configuration. Get this from @BotFather on Telegram
+BOT_TOKEN="your_telegram_bot_token_here"
+
+# IDS to send Exceptions errors to in private messages. Get this from bot healthcheck
+ADMINS_CHAT_IDS="your_admins_chat_id_here"  #ADMINS_CHAT_IDS=chatid_1,chatid_2,chatid_3
+
+# Send errors to admins in private messages
+SEND_ERROR_TO_ADMIN=True
 
 # Log Level
 LOG_LEVEL=INFO  # Set the Log Level (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/README.md
+++ b/README.md
@@ -176,4 +176,20 @@ LIMIT_BOT_ACCESS=False  # If True, the bot will only work for users in ALLOWED_U
 ALLOWED_USERNAMES= # a list of allowed usernames as strings separated by commas. Example: ALLOWED_USERNAMES=username1,username2,username3
 ALLOWED_CHAT_IDS= # a list of allowed chat IDs as strings separated by commas. Example: ALLOWED_CHAT_IDS=-412349,12345,123456
 ```
+
+## Troubleshooting
+If you sent a link to the bot and got no response, send the word `bot_health` or `ботяра` to the bot to check if it's working.
+
+- in .env file set IDS to send Exceptions errors to in private messages to Admins. Get these ids from bot healthcheck.
+Works only for Exceptions errors that are not handled by the bot code.
+
+```ini
+ADMINS_CHAT_IDS="your_admins_chat_id_here"  # ADMINS_CHAT_IDS=chatid_1,chatid_2,chatid_3
+```
+
+- in .env file set SEND_ERROR_TO_ADMIN=True to send errors to admins in private messages
+
+```ini
+SEND_ERROR_TO_ADMIN=True
+```
 ---

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ language = os.getenv("LANGUAGE", "ua").lower()
 admins_chat_ids = os.getenv("ADMINS_CHAT_IDS")
 send_error_to_admin = os.getenv("SEND_ERROR_TO_ADMIN", "False").lower() == "true"
 
+
 # Cache responses from JSON file
 @lru_cache(maxsize=1)
 def load_responses():
@@ -120,9 +121,9 @@ def is_large_file(file_path: str, max_size_mb: int = 50) -> bool:
 
 async def error_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Log the error and send a message to the admins.
-        Works only if SEND_ERROR_TO_ADMIN=True in .env file. and ADMINS_CHAT_IDS is set.
-        If SEND_ERROR_TO_ADMIN=False, the error will be logged but not sent to admins.
-        Works only for Exceptions errors that are not handled by the bot code.
+    Works only if SEND_ERROR_TO_ADMIN=True in .env file. and ADMINS_CHAT_IDS is set.
+    If SEND_ERROR_TO_ADMIN=False, the error will be logged but not sent to admins.
+    Works only for Exceptions errors that are not handled by the bot code.
     """
     username = update.effective_sender.username
     debug("User username: %s", username)


### PR DESCRIPTION
## Troubleshooting
If you sent a link to the bot and got no response, send the word `bot_health` or `ботяра` to the bot to check if it's working.

- in `.env` file set IDS to send Exceptions errors in private messages to Admins. Get these ids from bot healthcheck.
Works only for Exceptions errors that are not handled by the bot code.

```ini
ADMINS_CHAT_IDS="your_admins_chat_id_here"  # ADMINS_CHAT_IDS=chatid_1,chatid_2,chatid_3
```

- in ` .env` file set ```SEND_ERROR_TO_ADMIN=True``` to send errors to admins in private messages

```ini
SEND_ERROR_TO_ADMIN=True
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added troubleshooting section in README
	- Introduced error reporting capabilities for administrators
	- Added ability to send unhandled error messages to specified admin chat IDs

- **Configuration Updates**
	- New environment variables for admin error notifications
	- Option to enable/disable sending errors to administrators

- **Improvements**
	- Enhanced error handling and logging mechanisms
	- Provided clearer guidance for bot health checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->