### PR TITLE
feat:add Instagram story/carousel support with gallery-dl fallback 

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The expected waiting time for videos up to 10 minutes is 3-10 minutes depending 
 ### Instagram Stories and Carousels with Pictures
 - The bot now supports downloading Instagram stories and carousels with pictures using `gallery-dl` when `yt-dlp` fails.
 - To enable this feature, ensure you have `gallery-dl` installed and configured.
-- The bot will automatically fallback to `gallery-dl` for Instagram URLs without "reels" when `yt-dlp` fails.
+- The bot will automatically fall back to `gallery-dl` for Instagram URLs without "reels" when `yt-dlp` fails.
 - The same cookies file used for `yt-dlp` can be used for `gallery-dl`
 
 ## Access Control with Safe List

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ The expected waiting time for videos up to 10 minutes is 3-10 minutes depending 
 - Suggestion on how to get the file: easy export with [chrome extension](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
 - When you run the bot with Docker, place `instagram_cookies.txt` to the folder with your `.env` file and add `-v instagram_cookies.txt:/bot/instagram_cookies.txt` to the start command
 
+### Instagram Stories and Carousels with Pictures
+- The bot now supports downloading Instagram stories and carousels with pictures using `gallery-dl` when `yt-dlp` fails.
+- To enable this feature, ensure you have `gallery-dl` installed and configured.
+- The bot will automatically fallback to `gallery-dl` for Instagram URLs without "reels" when `yt-dlp` fails.
+- The same cookies file used for `yt-dlp` can be used for `gallery-dl`
+
 ## Access Control with Safe List
 The bot can use 'Safelist' to restrict access for users or groups.
 Ensure these variables are set in your `.env` file, without them or with the chat ID and username.

--- a/README.md
+++ b/README.md
@@ -176,11 +176,8 @@ The expected waiting time for videos up to 10 minutes is 3-10 minutes depending 
 - You can use the `instagram_cookies_example.txt` file as a reference from the `src` folder of the repo.
 - Suggestion on how to get the file: easy export with [chrome extension](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
 - When you run the bot with Docker, place `instagram_cookies.txt` to the folder with your `.env` file and add `-v instagram_cookies.txt:/bot/instagram_cookies.txt` to the start command
-
-### Instagram Stories and Carousels with Pictures
-- The bot now supports downloading Instagram stories and carousels with pictures using `gallery-dl` when `yt-dlp` fails.
-- To enable this feature, ensure you have `gallery-dl` installed and configured.
-- The bot will automatically fall back to `gallery-dl` for Instagram URLs without "reels" when `yt-dlp` fails.
+- The bot supports downloading Instagram stories and carousels with pictures using `gallery-dl` when `yt-dlp` fails.
+- The bot will automatically fall back to `gallery-dl` for Instagram URLs without `reels` when `yt-dlp` fails, multiple media files is supported.
 - The same cookies file used for `yt-dlp` can be used for `gallery-dl`
 
 ## Access Control with Safe List

--- a/src/main.py
+++ b/src/main.py
@@ -223,7 +223,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
 
     try:
         # media_path can be string or list of strings
-        media_path = [] # Initilize empty list of media paths
+        media_path = []  # Initilize empty list of media paths
         video_path = []  # Initilize empty list of video paths
         pic_path = []  # Initilize empty list of picture paths
         return_path = download_video(url)

--- a/src/main.py
+++ b/src/main.py
@@ -270,6 +270,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
 
     finally:
         if media_path:
+            debug("Cleaning up temporary files.")
             cleanup_file(media_path)
 
 
@@ -305,6 +306,11 @@ async def send_video(update: Update, video: str, has_spoiler: bool) -> None:
     """
     try:
         with open(video, 'rb') as video_file:
+            debug("Sending video to chat.")
+            debug("Video has spoiler: %s", has_spoiler)
+            debug("Video path: %s", video)
+            debug("Chat ID: %s", update.message.chat.id)
+            debug("Video path type: %s", type(video))
             await update.message.chat.send_video(
                 video=video_file,
                 has_spoiler=has_spoiler,

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ from general_error_handler import error_handler
 from permissions import inform_user_not_allowed, is_user_or_chat_not_allowed, supported_sites
 from video_utils import (
     compress_video,
-    download_video,
+    download_media,
     cleanup,
     is_video_duration_over_limits,
     is_video_too_long_to_download,
@@ -202,7 +202,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
         media_path = []  # Initilize empty list of media paths
         video_path = []  # Initilize empty list of video paths
         pic_path = []  # Initilize empty list of picture paths
-        return_path = download_video(url)
+        return_path = download_media(url)
         # Create a list of media paths
         if isinstance(return_path, list):
             media_path.extend(return_path)

--- a/src/main.py
+++ b/src/main.py
@@ -227,16 +227,19 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
         video_path = []  # Initilize empty list of video paths
         pic_path = []  # Initilize empty list of picture paths
         return_path = download_video(url)
-        # Addpend the return_path to media_path
-        media_path.append(return_path)
+        # Create a list of media paths
+        if isinstance(return_path, list):
+            media_path.extend(return_path)
+        else:
+            media_path.append(return_path)
 
-        for path in media_path:
+        for pathobj in media_path:
 
             # Create a lists of video and picture paths
-            if path.endswith(".mp4"):
-                video_path.append(path)
-            elif path.endswith(".jpg", ".jpeg", ".png"):
-                pic_path.append(path)
+            if pathobj.endswith(".mp4"):
+                video_path.append(pathobj)
+            elif pathobj.endswith((".jpg", ".jpeg", ".png")):
+                pic_path.append(pathobj)
 
         for video in video_path:
             # Compress video if it's larger than 50MB
@@ -260,7 +263,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
 
         for pic in pic_path:
             # Send the picture to the chat
-            send_pic(update, pic)
+            await send_pic(update, pic)
 
     finally:
         if media_path:
@@ -312,7 +315,7 @@ async def send_video(update: Update, video: str, has_spoiler: bool) -> None:
         await update.message.reply_text(f"Error sending video: {str(e)}. Please try again later.")
 
 
-async def send_pic(update: Update, picture: str) -> None:
+async def send_pic(update: Update, pic: str) -> None:
     """
     Sends the picture to the chat.
 
@@ -325,7 +328,7 @@ async def send_pic(update: Update, picture: str) -> None:
         None
     """
     try:
-        with open(picture, 'rb') as pic_file:
+        with open(pic, 'rb') as pic_file:
             await update.message.chat.send_photo(
                 photo=pic_file,
                 disable_notification=True,

--- a/src/main.py
+++ b/src/main.py
@@ -308,8 +308,7 @@ async def send_pic(update: Update, pic: str) -> None:
     Sends the picture to the chat.
     Args:
         update (telegram.Update): Represents the incoming update from the Telegram bot.
-        video_path (str): The path to the video file to send.
-        has_spoiler (bool): Indicates if the message contains a spoiler.
+        pic (str): The path to the pictures file to send.
     Returns:
         None
     """

--- a/src/main.py
+++ b/src/main.py
@@ -231,19 +231,14 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
         media_path.append(return_path)
 
         for path in media_path:
-            debug("Media downloaded to: %s", path)
 
             # Create a lists of video and picture paths
             if path.endswith(".mp4"):
                 video_path.append(path)
-                debug("Media detected as video: %s", path)
             elif path.endswith(".jpg", ".jpeg", ".png"):
                 pic_path.append(path)
-                debug("Media detected as picture: %s", path)
 
         for video in video_path:
-
-            debug("Processing video: %s", video)
             # Compress video if it's larger than 50MB
             # do not process compression if video is too long
             if is_video_duration_over_limits(video):
@@ -261,7 +256,6 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
                 continue  # Stop further execution for this video
 
             # Send the video to the chat
-            debug("Sending video to chat: %s", video)
             await send_video(update, video, has_spoiler)
 
         for pic in pic_path:
@@ -270,7 +264,6 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
 
     finally:
         if media_path:
-            debug("Cleaning up temporary files.")
             cleanup_file(media_path)
 
 
@@ -306,11 +299,6 @@ async def send_video(update: Update, video: str, has_spoiler: bool) -> None:
     """
     try:
         with open(video, 'rb') as video_file:
-            debug("Sending video to chat.")
-            debug("Video has spoiler: %s", has_spoiler)
-            debug("Video path: %s", video)
-            debug("Chat ID: %s", update.message.chat.id)
-            debug("Video path type: %s", type(video))
             await update.message.chat.send_video(
                 video=video_file,
                 has_spoiler=has_spoiler,

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,9 @@ language = os.getenv("LANGUAGE", "ua").lower()
 admins_chat_ids = os.getenv("ADMINS_CHAT_IDS")
 send_error_to_admin = os.getenv("SEND_ERROR_TO_ADMIN", "False").lower() == "true"
 
+TELEGRAM_WRITE_TIMEOUT = 8000
+TELEGRAM_READ_TIMEOUT = 8000
+
 
 # Cache responses from JSON file
 @lru_cache(maxsize=1)
@@ -245,7 +248,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
             # Compress video if it's larger than 50MB
             # do not process compression if video is too long
             if is_video_duration_over_limits(video):
-                await update.message.reply_text("The video is too large to send (over 50MB).")
+                await update.message.reply_text("The video is too long to send (over 12min).")
                 continue  # Drop the video and continue to the next one
 
             if is_large_file(video):
@@ -306,8 +309,8 @@ async def send_video(update: Update, video: str, has_spoiler: bool) -> None:
                 video=video_file,
                 has_spoiler=has_spoiler,
                 disable_notification=True,
-                write_timeout=8000,
-                read_timeout=8000,
+                write_timeout=TELEGRAM_WRITE_TIMEOUT,
+                read_timeout=TELEGRAM_READ_TIMEOUT,
             )
     except TimedOut as e:
         error("Telegram timeout while sending video. %s", e)
@@ -318,12 +321,10 @@ async def send_video(update: Update, video: str, has_spoiler: bool) -> None:
 async def send_pic(update: Update, pic: str) -> None:
     """
     Sends the picture to the chat.
-
     Args:
         update (telegram.Update): Represents the incoming update from the Telegram bot.
         video_path (str): The path to the video file to send.
         has_spoiler (bool): Indicates if the message contains a spoiler.
-
     Returns:
         None
     """
@@ -332,8 +333,8 @@ async def send_pic(update: Update, pic: str) -> None:
             await update.message.chat.send_photo(
                 photo=pic_file,
                 disable_notification=True,
-                write_timeout=8000,
-                read_timeout=8000,
+                write_timeout=TELEGRAM_WRITE_TIMEOUT,
+                read_timeout=TELEGRAM_READ_TIMEOUT,
             )
     except TimedOut as e:
         error("Telegram timeout while sending picture. %s", e)

--- a/src/main.py
+++ b/src/main.py
@@ -259,14 +259,14 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
             await send_video(update, video, has_spoiler)
             # wait 5 seconds before sending the next media throttle is enabled
             if THROTTLE:
-                time.sleep(5)
+                time.sleep(15)
 
         for pic in pic_path:
             # Send the picture to the chat
             await send_pic(update, pic)
             # wait 5 seconds before sending the next video if throttle is enabled
             if THROTTLE:
-                time.sleep(5)
+                time.sleep(15)
 
     finally:
         if media_path:

--- a/src/main.py
+++ b/src/main.py
@@ -316,12 +316,17 @@ async def send_video(update: Update, video, has_spoiler: bool) -> None:
             error("Telegram timeout while sending video. %s", e)
         except (NetworkError, TelegramError) as e:
             await update.message.reply_text(f"Error sending video: {str(e)}. Please try again later.")
+        finally:
+            video_file.close()
 
     # Send the group of videos
     elif isinstance(video, list):
         media_group = []
+        opened_files = []
         for video_file in video:
-            media_group.append(InputMediaVideo(open(video_file, 'rb')))
+            file = open(video_file, 'rb')
+            opened_files.append(file)
+            media_group.append(InputMediaVideo(file))
         debug("Sending a group with number of videos: %s", len(media_group))
         try:
             await update.message.chat.send_media_group(
@@ -334,6 +339,9 @@ async def send_video(update: Update, video, has_spoiler: bool) -> None:
             error("Telegram timeout while sending group of videos. %s", e)
         except (NetworkError, TelegramError) as e:
             await update.message.reply_text(f"Error sending group of videos: {str(e)}. Please try again later.")
+        finally:
+            for file in opened_files:
+                file.close()
 
 
 async def send_pic(update: Update, pic) -> None:
@@ -359,11 +367,16 @@ async def send_pic(update: Update, pic) -> None:
             error("Telegram timeout while sending picture. %s", e)
         except (NetworkError, TelegramError) as e:
             await update.message.reply_text(f"Error sending picture: {str(e)}. Please try again later.")
+        finally:
+            pic_file.close()
 
     elif isinstance(pic, list):
         media_group = []  # Initilize empty list of media groups
+        opened_files = []  # Initilize empty list of opened files
         for pic_file in pic:
-            media_group.append(InputMediaPhoto(open(pic_file, 'rb')))
+            file = open(pic_file, 'rb')
+            opened_files.append(file)
+            media_group.append(InputMediaPhoto(file))
         debug("Sending a group with number of pictures: %s", len(media_group))
         # Send the media group
         try:
@@ -377,6 +390,9 @@ async def send_pic(update: Update, pic) -> None:
             error("Telegram timeout while sending group of pictures. %s", e)
         except (NetworkError, TelegramError) as e:
             await update.message.reply_text(f"Error sending group of pictures: {str(e)}. Please try again later.")
+        finally:
+            for file in opened_files:
+                file.close()
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,6 @@
 import os
 import random
 import json
-import time
 import asyncio
 from functools import lru_cache
 from dotenv import load_dotenv
@@ -323,8 +322,8 @@ async def send_video(update: Update, video, has_spoiler: bool) -> None:
 
     # Send the group of videos
     elif isinstance(video, list):
-        media_group = []
-        opened_files = []
+        media_group = []  # Initilize empty list of media groups
+        opened_files = []  # Initilize empty list of opened files
         for video_file in video:
             file = open(video_file, 'rb')
             opened_files.append(file)

--- a/src/main.py
+++ b/src/main.py
@@ -261,18 +261,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
                 continue  # Stop further execution for this video
 
             # Send the video to the chat
-            debug("Sending video to chat.")
+            debug("Sending video to chat: %s", video)
             await send_video(update, video, has_spoiler)
 
         for pic in pic_path:
             # Send the picture to the chat
-            with open(pic, 'rb') as pic_file:
-                await update.message.chat.send_photo(
-                    photo=pic_file,
-                    disable_notification=True,
-                    write_timeout=8000,
-                    read_timeout=8000,
-                )
+            send_pic(update, pic)
 
     finally:
         if media_path:
@@ -297,20 +291,20 @@ async def respond_with_bot_message(update: Update) -> None:
     )
 
 
-async def send_video(update: Update, video_path: str, has_spoiler: bool) -> None:
+async def send_video(update: Update, video: str, has_spoiler: bool) -> None:
     """
     Sends the video to the chat.
 
     Args:
         update (telegram.Update): Represents the incoming update from the Telegram bot.
-        video_path (str): The path to the video file to send.
+        video (str): The path to the video file to send.
         has_spoiler (bool): Indicates if the message contains a spoiler.
 
     Returns:
         None
     """
     try:
-        with open(video_path, 'rb') as video_file:
+        with open(video, 'rb') as video_file:
             await update.message.chat.send_video(
                 video=video_file,
                 has_spoiler=has_spoiler,
@@ -322,6 +316,32 @@ async def send_video(update: Update, video_path: str, has_spoiler: bool) -> None
         error("Telegram timeout while sending video. %s", e)
     except (NetworkError, TelegramError) as e:
         await update.message.reply_text(f"Error sending video: {str(e)}. Please try again later.")
+
+
+async def send_pic(update: Update, picture: str) -> None:
+    """
+    Sends the picture to the chat.
+
+    Args:
+        update (telegram.Update): Represents the incoming update from the Telegram bot.
+        video_path (str): The path to the video file to send.
+        has_spoiler (bool): Indicates if the message contains a spoiler.
+
+    Returns:
+        None
+    """
+    try:
+        with open(picture, 'rb') as pic_file:
+            await update.message.chat.send_photo(
+                photo=pic_file,
+                disable_notification=True,
+                write_timeout=8000,
+                read_timeout=8000,
+            )
+    except TimedOut as e:
+        error("Telegram timeout while sending picture. %s", e)
+    except (NetworkError, TelegramError) as e:
+        await update.message.reply_text(f"Error sending picture: {str(e)}. Please try again later.")
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -236,7 +236,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
         if len(video_path) > 1:
             # Group videos
             video_path = [video_path[i : i + 2] for i in range(0, len(video_path), 2)]
-            # TODO: Implement a total size calculation for the group of videos
+            # TODO: Implement a total size calculation for the group of videos  # pylint: disable=fixme
             # and resort to sending them one by one if the total size exceeds the limit
 
         if len(pic_path) > 1:

--- a/src/main.py
+++ b/src/main.py
@@ -223,20 +223,27 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
 
     try:
         # media_path can be string or list of strings
-        media_path = download_video(url)
+        media_path = [] # Initilize empty list of media paths
         video_path = []  # Initilize empty list of video paths
         pic_path = []  # Initilize empty list of picture paths
+        return_path = download_video(url)
+        # Addpend the return_path to media_path
+        media_path.append(return_path)
 
         for path in media_path:
-            debug("Media downloaded to: %s", video_path)
+            debug("Media downloaded to: %s", path)
 
             # Create a lists of video and picture paths
             if path.endswith(".mp4"):
                 video_path.append(path)
+                debug("Media detected as video: %s", path)
             elif path.endswith(".jpg", ".jpeg", ".png"):
                 pic_path.append(path)
+                debug("Media detected as picture: %s", path)
 
         for video in video_path:
+
+            debug("Processing video: %s", video)
             # Compress video if it's larger than 50MB
             # do not process compression if video is too long
             if is_video_duration_over_limits(video):
@@ -254,6 +261,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
                 continue  # Stop further execution for this video
 
             # Send the video to the chat
+            debug("Sending video to chat.")
             await send_video(update, video, has_spoiler)
 
         for pic in pic_path:

--- a/src/main.py
+++ b/src/main.py
@@ -219,13 +219,13 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
             # Create a lists of video and picture paths
             if pathobj.endswith(".mp4"):
                 # do not process if video is too long
-                if is_video_duration_over_limits(video):
+                if is_video_duration_over_limits(pathobj):
                     await update.message.reply_text("The video is too long to send (over 12min).")
                     continue  # Drop the video and continue to the next one
                 # Compress the video if it's too large
-                if is_large_file(video):
-                    compress_video(video)
-                    if is_large_file(video):
+                if is_large_file(pathobj):
+                    compress_video(pathobj)
+                    if is_large_file(pathobj):
                         await update.message.reply_text("The video is too large to send (over 50MB).")
                         continue  # Stop further execution for this video
                 video_path.append(pathobj)
@@ -255,7 +255,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
 
     finally:
         if media_path:
-            cleanup_file(media_path)
+            cleanup(media_path)
 
 
 async def respond_with_bot_message(update: Update) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -234,15 +234,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
                 pic_path.append(pathobj)
 
         if len(video_path) > 1:
-            debug("Amount of videos: %s, let's group them", len(video_path))
             # Group videos
             video_path = [video_path[i : i + 2] for i in range(0, len(video_path), 2)]
             # TODO: Implement a total size calculation for the group of videos
             # and resort to sending them one by one if the total size exceeds the limit
-            debug("Grouped videos length: %s", len(video_path))
 
         if len(pic_path) > 1:
-            debug("Amount of photo: %s, let's group them", len(pic_path))
             # Group videos
             pic_path = [pic_path[i : i + 10] for i in range(0, len(pic_path), 10)]
             debug("Grouped pictures length: %s", len(pic_path))
@@ -325,8 +322,7 @@ async def send_video(update: Update, video, has_spoiler: bool) -> None:
         media_group = []
         for video_file in video:
             media_group.append(InputMediaVideo(open(video_file, 'rb')))
-        debug("Group of videos: %s", media_group)
-        debug("Sending a group of videos")
+        debug("Sending a group with number of videos: %s", len(media_group))
         try:
             await update.message.chat.send_media_group(
                 media=media_group,
@@ -368,8 +364,7 @@ async def send_pic(update: Update, pic) -> None:
         media_group = []  # Initilize empty list of media groups
         for pic_file in pic:
             media_group.append(InputMediaPhoto(open(pic_file, 'rb')))
-        debug("Group of pictures: %s", media_group)
-        debug("Sending a group of pictures")
+        debug("Sending a group with number of pictures: %s", len(media_group))
         # Send the media group
         try:
             await update.message.chat.send_media_group(

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import os
 import random
 import json
 import time
+import asyncio
 from functools import lru_cache
 from dotenv import load_dotenv
 from telegram import Update, InputMediaPhoto, InputMediaVideo
@@ -240,7 +241,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
             # and resort to sending them one by one if the total size exceeds the limit
 
         if len(pic_path) > 1:
-            # Group videos
+            # Group pictures
             pic_path = [pic_path[i : i + 10] for i in range(0, len(pic_path), 10)]
             debug("Grouped pictures length: %s", len(pic_path))
 
@@ -256,14 +257,14 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
             await send_video(update, video, has_spoiler)
             # wait 5 seconds before sending the next media throttle is enabled
             if THROTTLE:
-                time.sleep(15)
+                await asyncio.sleep(15)
 
         for pic in pic_path:
             # Send the picture to the chat
             await send_pic(update, pic)
             # wait 5 seconds before sending the next video if throttle is enabled
             if THROTTLE:
-                time.sleep(15)
+                await asyncio.sleep(15)
 
     finally:
         if media_path:
@@ -294,7 +295,8 @@ async def send_video(update: Update, video, has_spoiler: bool) -> None:
 
     Args:
         update (telegram.Update): Represents the incoming update from the Telegram bot.
-        video (str or list): The path to the video file to send.
+        video (str or list): The path to the video file to send. If a list is provided,
+            the videos will be sent as a media group with up to 2 videos per group.
         has_spoiler (bool): Indicates if the message contains a spoiler.
 
     Returns:
@@ -349,7 +351,8 @@ async def send_pic(update: Update, pic) -> None:
     Sends the picture to the chat.
     Args:
         update (telegram.Update): Represents the incoming update from the Telegram bot.
-        pic (str or list): The path to the pictures file to send.
+        pic (str or list): The path to the picture file to send. If a list is provided,
+            the pictures will be sent as a media group with up to 10 pictures per group.
     Returns:
         None
     """

--- a/src/main.py
+++ b/src/main.py
@@ -224,8 +224,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
     try:
         # media_path can be string or list of strings
         media_path = download_video(url)
-        video_path = [] # Initilize empty list of video paths
-        pic_path = [] # Initilize empty list of picture paths
+        video_path = []  # Initilize empty list of video paths
+        pic_path = []  # Initilize empty list of picture paths
 
         for path in media_path:
             debug("Media downloaded to: %s", video_path)
@@ -256,16 +256,15 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):  #
             # Send the video to the chat
             await send_video(update, video, has_spoiler)
 
-    for pic in pic_path:
-        # Send the picture to the chat
-        with open(pic, 'rb') as pic_file:
-            await update.message.chat.send_photo(
-                photo=pic_file,
-                disable_notification=True,
-                write_timeout=8000,
-                read_timeout=8000,
-            )
-
+        for pic in pic_path:
+            # Send the picture to the chat
+            with open(pic, 'rb') as pic_file:
+                await update.message.chat.send_photo(
+                    photo=pic_file,
+                    disable_notification=True,
+                    write_timeout=8000,
+                    read_timeout=8000,
+                )
 
     finally:
         if media_path:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
 python-telegram-bot[ext]==21.10
 python-dotenv==1.0.1
 yt-dlp==2025.1.26
+gallery-dl==1.28.5

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -280,8 +280,8 @@ def download_media(url):
                 return result_path
             else:
                 error("Failed to download Instagram media using gallery-dl")
-        except Exception as e:  # pylint: disable=broad-except
-            error("Unexpected error during Instagram download images by gallery-dl: %s", e)
+        except Exception as gallery_dl_error:  # pylint: disable=broad-except
+            error("Unexpected error during Instagram download images by gallery-dl: %s", gallery_dl_error)
     except subprocess.TimeoutExpired as e:
         error("Download process timed out: %s", e)
     except (OSError, IOError) as e:

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -201,7 +201,6 @@ def download_instagram_media(url, temp_dir):
     ]
 
     debug("Downloading Instagram media from URL: %s", url)
-    result_path = None  # Initialize the result variable
 
     try:
         subprocess.run(command, check=True, timeout=120)

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -298,7 +298,7 @@ def download_media(url):
     return result_path  # Return the result variable at the end
 
 
-def cleanup_file(media_path):
+def cleanup(media_path):
     """
     Cleans up temporary files by deleting the specified video file and its containing directory.
 

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -163,6 +163,7 @@ def get_video_duration(video_path):
         error("Error getting video duration: %s", e)
         return None
 
+
 def download_instagram_media(url):
     """
     Downloads Instagram media using gallery-dl.
@@ -203,6 +204,7 @@ def download_instagram_media(url):
         error("File system error occurred: %s", e)
 
     return result_path  # Return the result variable at the end
+
 
 def download_video(url):
     """

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import yt_dlp
 from dotenv import load_dotenv
 from logger import debug, error
 from pathlib import Path
@@ -263,7 +264,9 @@ def download_video(url):
         for filename in os.listdir(temp_dir):
             if filename.endswith(".mp4"):
                 result_path = os.path.join(temp_dir, filename)
-                break  # Exit the loop once the file is found
+                debug("Video file found: %s", result_path)
+                return result_path  # Exit the loop once the file is found
+
     except subprocess.CalledProcessError as e:
         error("Error downloading video: %s", e)
         if "[Instagram]" in str(e) and "No video formats found!" in str(e):
@@ -272,6 +275,7 @@ def download_video(url):
             result_path = download_instagram_images(url, temp_dir)
             if result_path:
                 debug("Successfully downloaded Instagram media using gallery-dl")
+                return result_path
             else:
                 error("Failed to download Instagram media using gallery-dl")
         except Exception as ed:  # pylint: disable=broad-except
@@ -299,22 +303,17 @@ def cleanup_file(media_path):
     its parent directory. Logs are printed if debugging is enabled.
 
     Parameters:
-        video_path (str): The path to the video file to delete.
+        video_path (list): The path to the video file to delete.
 
     Logs:
         Logs messages about the deletion process or any errors encountered.
     """
 
     folder_to_delete = None
-    if isinstance(media_path, str):
-        try:
-            folder_to_delete = Path(media_path).parts[1]
-        except (OSError, IOError):
-            debug("Unable to find temp folder for %s", media_path)
-            return
     if isinstance(media_path, list):
         try:
-            folder_to_delete = Path(media_path[0]).parts[1]
+            folder_to_delete = "/" + str(Path(media_path[0].parts[1])) + str(Path(media_path[0].parts[1]))
+            debug("Temp folder to delete: %s", folder_to_delete)
         except (OSError, IOError):
             debug("Unable to find temp folder for %s", media_path[0])
             return

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -308,13 +308,13 @@ def cleanup_file(media_path):
     folder_to_delete = None
     if isinstance(media_path, str):
         try:
-            folder_to_delete = Path(media_path).parts[1])
+            folder_to_delete = Path(media_path).parts[1]
         except (OSError, IOError):
             debug("Unable to find temp folder for %s", media_path)
             return
     if isinstance(media_path, list):
         try:
-            folder_to_delete = Path(media_path[0]).parts[1])
+            folder_to_delete = Path(media_path[0]).parts[1]
         except (OSError, IOError):
             debug("Unable to find temp folder for %s", media_path[0])
             return

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -164,7 +164,7 @@ def get_video_duration(video_path):
         return None
 
 
-def download_instagram_media(url):
+def download_instagram_media(url, temp_dir):
     """
     Downloads Instagram media using gallery-dl.
 
@@ -174,11 +174,18 @@ def download_instagram_media(url):
 
     Parameters:
         url (str): The URL of the Instagram media to download.
+        temp_dir (str): The path to the temporary directory to store the downloaded media.
 
     Returns:
         str: The path to the downloaded media file if successful, or None if the download fails.
     """
-    temp_dir = tempfile.mkdtemp()
+    result_path = None  # Initialize the result variable
+
+    # Ensure that reels not in the URL
+    if "reel" in url:
+        error("Reels shoud be handled by the yt-dlp")
+        return None
+
     command = [
         "gallery-dl",  # Assuming gallery-dl is installed and in the PATH
         *(["--cookies", "instagram_cookies.txt"] if INSTACOOKIES else []),
@@ -250,7 +257,7 @@ def download_video(url):
         error("Error downloading video: %s", e)
         if "[Instagram]" in str(e) and "No video formats found!" in str(e):
             debug("yt-dlp failed for Instagram URL, trying gallery-dl")
-            result_path = download_instagram_media(url)
+            result_path = download_instagram_media(url, temp_dir)
     except subprocess.TimeoutExpired as e:
         error("Download process timed out: %s", e)
     except (OSError, IOError) as e:

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -9,7 +9,7 @@ import tempfile
 import yt_dlp
 from dotenv import load_dotenv
 from logger import debug, error
-from pathlib import PurePath
+from pathlib import PurePath, Path
 
 load_dotenv()  # Load environment variables from .env file
 
@@ -207,14 +207,15 @@ def download_instagram_images(url, temp_dir):
         result_path = []  # Initialize the result variable as a empty list
         # Use Path.rglob to recursively search for files in the temp directory
         # as the output contains subdirectories and may contain multiple files
-        for file in [str(file) for file in Path(temp_output).rglob("*")]:
-            if filename.endswith((".mp4", ".jpg", ".jpeg", ".png")):
+        for file in [str(file) for file in Path(temp_dir).rglob("*")]:
+            if file.endswith((".mp4", ".jpg", ".jpeg", ".png")):
                 # Append the file path to the result list
                 result_path.append(file)
-                debug("Instagram media file found: %s", file)
         if not result_path:
             error("No media files found in the gallery-dl output")
             return None
+
+        return result_path  # Return the result variable if successful
     except subprocess.CalledProcessError as e:
         error("Error downloading Instagram media: %s", e)
     except subprocess.TimeoutExpired as e:
@@ -311,7 +312,7 @@ def cleanup_file(media_path):
     folder_to_delete = None
     if isinstance(media_path, list):
         try:
-            folder_to_delete = "/" + str(PurePath(media_path[0]).parts[1]) + str(PurePath(media_path[0]).parts[2])
+            folder_to_delete = "/" + str(PurePath(media_path[0]).parts[1]) + "/" + str(PurePath(media_path[0]).parts[2])
         except (OSError, IOError):
             debug("Unable to find temp folder for %s", media_path[0])
             return

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -322,7 +322,6 @@ def cleanup(media_path):
     debug("Temporary directory to delete %s", folder_to_delete)
     try:
         shutil.rmtree(folder_to_delete)
-        debug("Temp media folder %s deleted", folder_to_delete)
         if os.path.exists(folder_to_delete):
             error("Temporary directory still exists after cleanup: %s", folder_to_delete)
         else:

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -264,13 +264,13 @@ def download_video(url):
         if "[Instagram]" in str(e) and "No video formats found!" in str(e):
             debug("yt-dlp failed for Instagram URL, trying gallery-dl")
         try:
-            result_path = download_instagram_media(url)
+            result_path = download_instagram_media(url, temp_dir)
             if result_path:
                 debug("Successfully downloaded Instagram media using gallery-dl")
             else:
                 error("Failed to download Instagram media using gallery-dl")
-        except Exception as e:
-            error("Unexpected error during Instagram download: %s", e)
+        except Exception as ed: # pylint: disable=broad-except
+            error("Unexpected error during Instagram download: %s", ed)
     except subprocess.TimeoutExpired as e:
         error("Download process timed out: %s", e)
     except (OSError, IOError) as e:

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -291,7 +291,7 @@ def download_video(url):
     return result_path  # Return the result variable at the end
 
 
-def cleanup_file(video_path):
+def cleanup_file(media_path):
     """
     Deletes a video file and its containing directory.
 
@@ -304,9 +304,23 @@ def cleanup_file(video_path):
     Logs:
         Logs messages about the deletion process or any errors encountered.
     """
-    debug("Video to delete %s", video_path)
+
+    folder_to_delete = None
+    if isinstance(media_path, str):
+        try:
+            folder_to_delete = Path(media_path).parts[1])
+        except (OSError, IOError):
+            debug("Unable to find temp folder for %s", media_path)
+            return
+    if isinstance(media_path, list):
+        try:
+            folder_to_delete = Path(media_path[0]).parts[1])
+        except (OSError, IOError):
+            debug("Unable to find temp folder for %s", media_path[0])
+            return
+
     try:
-        shutil.rmtree(os.path.dirname(video_path))
-        debug("Video deleted %s", video_path)
+        shutil.rmtree(folder_to_delete)
+        debug("Temp media folder %s deleted", folder_to_delete)
     except (OSError, IOError) as cleanup_error:
-        error("Error deleting file: %s", cleanup_error)
+        error("Error deleting folder: %s", cleanup_error)

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -9,7 +9,7 @@ import tempfile
 import yt_dlp
 from dotenv import load_dotenv
 from logger import debug, error
-from pathlib import Path
+from pathlib import PurePath
 
 load_dotenv()  # Load environment variables from .env file
 
@@ -311,8 +311,9 @@ def cleanup_file(media_path):
 
     folder_to_delete = None
     if isinstance(media_path, list):
+        debug("Media path is a list: %s", media_path)
         try:
-            folder_to_delete = "/" + str(Path(media_path[0].parts[1])) + str(Path(media_path[0].parts[1]))
+            folder_to_delete = "/" + str(PurePath(media_path[0]).parts[1]) + str(PurePath(media_path[0]).parts[2])
             debug("Temp folder to delete: %s", folder_to_delete)
         except (OSError, IOError):
             debug("Unable to find temp folder for %s", media_path[0])

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -189,7 +189,7 @@ def download_instagram_media(url, temp_dir):
 
     # Ensure that reels not in the URL
     if "reel" in url:
-        error("Reels shoud be handled by the yt-dlp")
+        error("Reels should be handled by the yt-dlp")
         return None
 
     command = [
@@ -226,7 +226,7 @@ def download_video(url):
     This function uses the `yt-dlp` command-line tool to download a video. The video is stored
     in a temporary directory with a filename based on the video's title. The function
     returns the path to the downloaded video file if successful. If the download fails, "[Instagram]"
-    and "No video formats found!" present in the error message, the function will inwoke
+    and "No video formats found!" present in the error message, the function will invoke
     download_instagram_media based on `gallery-dl`.
 
     Parameters:

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -314,7 +314,8 @@ def cleanup(media_path):
     folder_to_delete = None
     if isinstance(media_path, list):
         try:
-            folder_to_delete = "/" + str(PurePath(media_path[0]).parts[1]) + "/" + str(PurePath(media_path[0]).parts[2])
+            first_media_path = PurePath(media_path[0])
+            folder_to_delete = f"/{first_media_path.parts[1]}/{first_media_path.parts[2]}"
         except (OSError, IOError):
             debug("Unable to find temp folder for %s", media_path[0])
             return

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -165,7 +165,7 @@ def get_video_duration(video_path):
         return None
 
 
-def download_instagram_media(url, temp_dir):
+def download_instagram_images(url, temp_dir):
     """
     Downloads Instagram media using gallery-dl.
 
@@ -263,7 +263,7 @@ def download_video(url):
         if "[Instagram]" in str(e) and "No video formats found!" in str(e):
             debug("yt-dlp failed for Instagram URL, trying gallery-dl")
         try:
-            result_path = download_instagram_media(url, temp_dir)
+            result_path = download_instagram_images(url, temp_dir)
             if result_path:
                 debug("Successfully downloaded Instagram media using gallery-dl")
             else:

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -166,7 +166,7 @@ def get_video_duration(video_path):
         return None
 
 
-def download_instagram_images(url, temp_dir):
+def download_instagram_media(url, temp_dir):
     """
     Downloads Instagram media using gallery-dl.
 
@@ -226,7 +226,7 @@ def download_instagram_images(url, temp_dir):
     return result_path  # Return the result variable at the end
 
 
-def download_video(url):
+def download_media(url):
     """
     Downloads a video from the specified URL using yt-dlp and saves it as an MP4 file.
 
@@ -234,13 +234,14 @@ def download_video(url):
     in a temporary directory with a filename based on the video's title. The function
     returns the path to the downloaded video file if successful. If the download fails, "[Instagram]"
     and "No video formats found!" present in the error message, the function will invoke
-    download_instagram_images based on `gallery-dl`.
+    download_instagram_media based on `gallery-dl`, and will return a list of media (may contain
+    videos, pictures or mix of them).
 
     Parameters:
         url (str): The URL of the video to download.
 
     Returns:
-        str: The path to the downloaded MP4 video file if successful, or None if the download fails.
+        list: The list of path to the downloaded media files if successful, or None if the download fails.
 
     Exceptions:
         Handles exceptions for subprocess errors, timeouts, or unexpected errors during the
@@ -273,7 +274,7 @@ def download_video(url):
         if "[Instagram]" in str(e) and "No video formats found!" in str(e):
             debug("yt-dlp failed for Instagram URL, trying gallery-dl")
         try:
-            result_path = download_instagram_images(url, temp_dir)
+            result_path = download_instagram_media(url, temp_dir)
             if result_path:
                 debug("Successfully downloaded Instagram media using gallery-dl")
                 return result_path

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -269,7 +269,7 @@ def download_video(url):
                 debug("Successfully downloaded Instagram media using gallery-dl")
             else:
                 error("Failed to download Instagram media using gallery-dl")
-        except Exception as ed: # pylint: disable=broad-except
+        except Exception as ed:  # pylint: disable=broad-except
             error("Unexpected error during Instagram download: %s", ed)
     except subprocess.TimeoutExpired as e:
         error("Download process timed out: %s", e)

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -234,7 +234,7 @@ def download_video(url):
     in a temporary directory with a filename based on the video's title. The function
     returns the path to the downloaded video file if successful. If the download fails, "[Instagram]"
     and "No video formats found!" present in the error message, the function will invoke
-    download_instagram_media based on `gallery-dl`.
+    download_instagram_images based on `gallery-dl`.
 
     Parameters:
         url (str): The URL of the video to download.

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -190,7 +190,7 @@ def download_instagram_media(url, temp_dir):
 
     # Ensure that reels not in the URL
     if "reel" in url:
-        error("Reels should be handled by the yt-dlp")
+        error("Reels should be handled by the yt-dlp. Abort.")
         return None
 
     command = [
@@ -272,7 +272,7 @@ def download_media(url):
     except subprocess.CalledProcessError as e:
         error("Error downloading video: %s", e)
         if "[Instagram]" in str(e) and "No video formats found!" in str(e):
-            debug("yt-dlp failed for Instagram URL, trying gallery-dl")
+            debug("The yt-dlp did not find Instagram reels, trying gallery-dl for images")
         try:
             result_path = download_instagram_media(url, temp_dir)
             if result_path:
@@ -280,12 +280,11 @@ def download_media(url):
                 return result_path
             else:
                 error("Failed to download Instagram media using gallery-dl")
-        except Exception as ed:  # pylint: disable=broad-except
-            error("Unexpected error during Instagram download: %s", ed)
+        except Exception as e:  # pylint: disable=broad-except
+            error("Unexpected error during Instagram download images by gallery-dl: %s", e)
     except subprocess.TimeoutExpired as e:
         error("Download process timed out: %s", e)
     except (OSError, IOError) as e:
-        debug("Downloading video from URL: %s", url)
         error("File system error occurred: %s", e)
     except yt_dlp.utils.DownloadError as e:
         error("Download error occurred: %s", e)
@@ -302,11 +301,11 @@ def cleanup(media_path):
     """
     Cleans up temporary files by deleting the specified video file and its containing directory.
 
-    This function attempts to remove the specified video file and
+    This function removes the specified media_path with video or images and
     its parent directory. Logs are printed if debugging is enabled.
 
     Parameters:
-        video_path (list): The path to the video file to delete.
+        media_path (list): The path to the video file to delete.
 
     Logs:
         Logs messages about the deletion process or any errors encountered.

--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -264,7 +264,6 @@ def download_video(url):
         for filename in os.listdir(temp_dir):
             if filename.endswith(".mp4"):
                 result_path = os.path.join(temp_dir, filename)
-                debug("Video file found: %s", result_path)
                 return result_path  # Exit the loop once the file is found
 
     except subprocess.CalledProcessError as e:
@@ -311,10 +310,8 @@ def cleanup_file(media_path):
 
     folder_to_delete = None
     if isinstance(media_path, list):
-        debug("Media path is a list: %s", media_path)
         try:
             folder_to_delete = "/" + str(PurePath(media_path[0]).parts[1]) + str(PurePath(media_path[0]).parts[2])
-            debug("Temp folder to delete: %s", folder_to_delete)
         except (OSError, IOError):
             debug("Unable to find temp folder for %s", media_path[0])
             return


### PR DESCRIPTION
Within this PR is added support of Instagram pictures and carousel with multiple media fixes, including a mix with picture and video

Adressed #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Now supports downloading Instagram stories and carousel images by automatically switching to an alternative tool when the primary method fails.
  - Enhanced media handling enables sending multiple videos and images in a single message with improved file management.

- **Documentation**
  - Updated instructions to guide users on installing and configuring the required tool, including guidance on using the same cookie configuration for seamless operation.
  - Clarified support for multiple media files when using the fallback tool.

- **Chores**
  - Added new dependency `gallery-dl==1.28.5` to the project requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->