### PR TITLE
fix: fix intendation to prevent using gallery-dl when it shoud not be

### DIFF
--- a/src/video_utils.py
+++ b/src/video_utils.py
@@ -273,15 +273,15 @@ def download_media(url):
         error("Error downloading video: %s", e)
         if "[Instagram]" in str(e) and "No video formats found!" in str(e):
             debug("The yt-dlp did not find Instagram reels, trying gallery-dl for images")
-        try:
-            result_path = download_instagram_media(url, temp_dir)
-            if result_path:
-                debug("Successfully downloaded Instagram media using gallery-dl")
-                return result_path
-            else:
-                error("Failed to download Instagram media using gallery-dl")
-        except Exception as gallery_dl_error:  # pylint: disable=broad-except
-            error("Unexpected error during Instagram download images by gallery-dl: %s", gallery_dl_error)
+            try:
+                result_path = download_instagram_media(url, temp_dir)
+                if result_path:
+                    debug("Successfully downloaded Instagram media using gallery-dl")
+                    return result_path
+                else:
+                    error("Failed to download Instagram media using gallery-dl")
+            except Exception as gallery_dl_error:  # pylint: disable=broad-except
+                error("Unexpected error during Instagram download images by gallery-dl: %s", gallery_dl_error)
     except subprocess.TimeoutExpired as e:
         error("Download process timed out: %s", e)
     except (OSError, IOError) as e:


### PR DESCRIPTION
I just discovered that the wrong indentation calls `download_instagram_media` for non-instagram media for case where `yt-dlp` failed (i.e. for case of `Error 403 caused by Cloudflare anti-bot challenge`).

This simple fix prevents that. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced internal error handling for media downloads to improve code clarity without changing the app's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->