### PR TITLE
make chatid and username configurable in chat response

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Telegram Bot Configuration. Get this from @BotFather on Telegram
 BOT_TOKEN="your_telegram_bot_token_here"
 
-# IDS to send Exceptions errors to in private messages. Get this from bot healthcheck
+# IDS to send Exceptions errors to in private messages. Get this from bot healthcheck with SEND_USER_INFO_WITH_HEALTHCHECK=True
 ADMINS_CHAT_IDS="your_admins_chat_id_here"  #ADMINS_CHAT_IDS=chatid_1,chatid_2,chatid_3
 
 # Send errors to admins in private messages
@@ -23,4 +23,4 @@ INSTACOOKIES=False  # False by default
 # Language Settings
 LANGUAGE=en  # Available options: en, uk. UK - Ukrainian by default
 
-HEALTHCHECK=False  # Enable to use healthchecks messages with Chat ID and username to caht. If disabled - to log only
+SEND_USER_INFO_WITH_HEALTHCHECK=False  # Send random messages with Chat ID and username to chat. If disabled - to log only

--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ INSTACOOKIES=False  # False by default
 
 # Language Settings
 LANGUAGE=en  # Available options: en, uk. UK - Ukrainian by default
+
+HEALTHCHECK=False  # Enable to use healthchecks messages with Chat ID and username to caht. If disabled - to log only

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,10 @@ language = os.getenv("LANGUAGE", "uk").lower()
 if language == "ua":
     language = "uk"
 
+# Healthcheck
+HEALTHCHECK = os.getenv("HEALTHCHECK", "False").lower() == "true"
+
+
 TELEGRAM_WRITE_TIMEOUT = 8000
 TELEGRAM_READ_TIMEOUT = 8000
 
@@ -284,11 +288,10 @@ async def respond_with_bot_message(update: Update) -> None:
         None
     """
     response_message = random.choice(responses)  # Select a random response from the predefined list
-    await update.message.reply_text(
-        f"{response_message}\n"
-        f"[Chat ID]: {update.effective_chat.id}\n"
-        f"[Username]: {update.effective_user.username}"
-    )
+    info("Healthcheck requested [Chat ID]: %s by the user %s", update.effective_chat.id, update.effective_user.username)
+    if HEALTHCHECK:
+        response_message += f"\n[Chat ID]: {update.effective_chat.id}\n[Username]: {update.effective_user.username}"
+    await update.message.reply_text(f"{response_message}")
 
 
 async def send_video(update: Update, video, has_spoiler: bool) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -29,8 +29,8 @@ language = os.getenv("LANGUAGE", "uk").lower()
 if language == "ua":
     language = "uk"
 
-# Healthcheck
-HEALTHCHECK = os.getenv("HEALTHCHECK", "False").lower() == "true"
+# Reply with user data for Healthcheck
+send_user_info_with_healthcheck = os.getenv("SEND_USER_INFO_WITH_HEALTHCHECK", "False").lower() == "true"
 
 
 TELEGRAM_WRITE_TIMEOUT = 8000
@@ -288,8 +288,8 @@ async def respond_with_bot_message(update: Update) -> None:
         None
     """
     response_message = random.choice(responses)  # Select a random response from the predefined list
-    info("Healthcheck requested [Chat ID]: %s by the user %s", update.effective_chat.id, update.effective_user.username)
-    if HEALTHCHECK:
+    info(" requested [Chat ID]: %s by the user %s", update.effective_chat.id, update.effective_user.username)
+    if send_user_info_with_healthcheck:
         response_message += f"\n[Chat ID]: {update.effective_chat.id}\n[Username]: {update.effective_user.username}"
     await update.message.reply_text(f"{response_message}")
 


### PR DESCRIPTION
In my particular case, chat users use heath check request as the part of the communication as response is funny, and can be easy extended with the adding custom message to json file that is mounded with `docker run -v`. In this case, a Chat ID and username is not required here.

With this PR they are configurable, and ChatID can be easy recovered in the logs, to do so even without debug enabled, they are in `INFO` log level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new health check option that allows users to enable enhanced health monitoring. When activated, bot responses now include additional details (such as chat information) to help track system status without altering existing configurations.
  - Added a new configuration option `SEND_USER_INFO_WITH_HEALTHCHECK` to manage user information logging during health checks.
- **Documentation**
  - Updated comments in the configuration file to clarify the usage of `SEND_USER_INFO_WITH_HEALTHCHECK`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->