### PR TITLE
fix: remove username from url only for insta

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -123,8 +123,9 @@ def clean_url(message_text: str) -> str:
     # Split by space and take the first part (the URL)
     url = url.split()[0]
 
-    # Remove any @username from the end of the URL
-    url = url.split('@')[0]
+    # Remove any @username from the end of the URL only if it's an Instagram URL
+    if "instagram.com" in url:
+        url = url.split('@')[0]
 
     return url
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,4 +2,4 @@ python-telegram-bot[ext]==22.0
 python-dotenv==1.1.0
 yt-dlp==2025.3.31
 gallery-dl==1.29.4
-aiohttp==3.9.3
+aiohttp==3.11.18


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL cleaning to ensure only Instagram URLs have trailing usernames removed, leaving other URLs unchanged.

- **Chores**
  - Updated the aiohttp dependency to version 3.11.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->